### PR TITLE
adjust shooter movement to match grid

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -8,7 +8,7 @@ function Board (width, height, canvas, context) {
   this.grid    = [];
   this.canvas  = canvas;
   this.context = context;
-  this.shooter = new Bubble(225, 440, 10, 0, canvas, context);
+  this.shooter = new Bubble(235, 440, 10, 0, canvas, context);
   this.bubbles = [this.shooter];
 
 // create rows in grid matrix, push bubbles onto those rows

--- a/lib/bubble.js
+++ b/lib/bubble.js
@@ -20,24 +20,26 @@ Bubble.prototype.draw = function() {
 };
 
 Bubble.prototype.checkInBounds = function() {
-  return this.x > 10 && this.x < 440 ? true : false;
+  return this.x > 15 && this.x < 433 ? true : false;
 };
 
 Bubble.prototype.moveLeft = function() {
   if (this.checkInBounds()) {
-    this.x = this.x - 5
-  } else if (!this.checkInBounds() && this.x === 440) {
-    this.x = this.x - 5
+    this.x = this.x - 22
+  } else if (!this.checkInBounds() && this.x === 433) {
+    this.x = this.x - 22
   }
+  console.log(this.x);
   return this;
 };
 
 Bubble.prototype.moveRight = function() {
   if (this.checkInBounds()) {
-    this.x = this.x + 5
-  } else if (!this.checkInBounds() && this.x === 10) {
-    this.x = this.x + 5
+    this.x = this.x + 22
+  } else if (!this.checkInBounds() && this.x === 15) {
+    this.x = this.x + 22
   }
+  console.log(this.x);
   return this;
 };
 

--- a/test/bubble_test.js
+++ b/test/bubble_test.js
@@ -22,59 +22,56 @@ describe('Bubble', function() {
     });
 
     it('can move left', function() {
-      let shooter = new Bubble(225, 440, 10);
+      let shooter = new Bubble(235, 440, 10);
       shooter.moveLeft();
 
-      assert.equal(shooter.x, 220);
+      assert.equal(shooter.x, 213);
       assert.equal(shooter.y, 440);
     });
 
     it('can move right', function() {
-      let shooter = new Bubble(225, 440, 10);
+      let shooter = new Bubble(235, 440, 10);
       shooter.moveRight();
 
-      assert.equal(shooter.x, 230);
+      assert.equal(shooter.x, 257);
       assert.equal(shooter.y, 440);
     });
 
     it('can move back and forth', function() {
-      let shooter = new Bubble(225, 440, 10);
+      let shooter = new Bubble(235, 440, 10);
       shooter.moveLeft().moveLeft().moveRight();
 
-      assert.equal(shooter.x, 220);
+      assert.equal(shooter.x, 213);
       assert.equal(shooter.y, 440);
     });
 
     it('cannot move past the left boundary', function() {
-      let shooter = new Bubble(15, 440, 10);
+      let shooter = new Bubble(40, 440, 10);
       shooter.moveLeft();
-      assert.equal(shooter.x, 10);
-
-      shooter.moveLeft();
-      assert.equal(shooter.x, 10);
+      assert.equal(shooter.x, 18);
     });
 
     it('can move right if on the left boundary', function() {
-      let shooter = new Bubble(10, 440, 10);
+      let shooter = new Bubble(20, 440, 10);
       shooter.moveRight();
 
-      assert.equal(shooter.x, 15);
+      assert.equal(shooter.x, 42);
     });
 
     it('cannot move past the right boundary', function() {
-      let shooter = new Bubble(435, 440, 10);
+      let shooter = new Bubble(411, 440, 10);
       shooter.moveRight();
-      assert.equal(shooter.x, 440);
+      assert.equal(shooter.x, 433);
 
       shooter.moveRight();
-      assert.equal(shooter.x, 440);
+      assert.equal(shooter.x, 433);
     });
 
     it('can move left if on the right boundary', function() {
-      let shooter = new Bubble(440, 440, 10);
+      let shooter = new Bubble(433, 440, 10);
       shooter.moveLeft();
 
-      assert.equal(shooter.x, 435);
+      assert.equal(shooter.x, 411);
     });
 
     it('shoots the ball when the spacebar is pressed', function() {


### PR DESCRIPTION
Shooter now moves in line with grid
Fixes weird overlap issues
Snap shooter into grid and readjust boundaries